### PR TITLE
New package: caosdb

### DIFF
--- a/packages/caosdb.yaml
+++ b/packages/caosdb.yaml
@@ -29,19 +29,26 @@ maintainers:
 - name: "Daniel Hornung"
   contact: "d.hornung@indiscale.com"
 versions:
-# TODO Update release data
-- id: "0.0.2"
-  date: "2021-xx-xx"
-  sha256: "bff441755f0d68596f2efd027fe637b5b6c52b722ffd6255bdb8a5f34ab4ef2a"
-  url: "https://github.com/gnu-octave/pkg-example/archive/1.1.0.tar.gz"
-  depends:
-  - "octave (>= 4.0.0)"
-  - "pkg"
+# TODO Update data after release
+# - id: "0.0.2"
+#   date: "2021-xx-xx"
+#   sha256: "bff441755f0d68596f2efd027fe637b5b6c52b722ffd6255bdb8a5f34ab4ef2a"
+#   url: "https://github.com/gnu-octave/pkg-example/archive/1.1.0.tar.gz"
+#   depends:
+#   - "octave (>= 4.4.0)"
+#   - "pkg"
 - id: "dev"
   date:
   sha256:
-  url: "https://gitlab.com/caosdb/caosdb-octavelib/-/archive/dev/caosdb-octavelib-dev.zip"
+  url: "https://gitlab.indiscale.com/caosdb/src/caosdb-octavelib/-/archive/dev/caosdb-octavelib-dev.tar.bz2"
   depends:
-  - "octave (>= 4.0.0)"
+  - "octave (>= 4.4.0)"
+  - "pkg"
+- id: "0.0.1"
+  date: "2021-09-17"
+  sha256: "56a221d83f363c94e667b610b309a2903532e358357e5ff7602e0314fea3ad4c"
+  url: "https://gitlab.indiscale.com/caosdb/src/caosdb-octavelib/-/archive/v0.0.1/caosdb-octavelib-v0.0.1.tar.bz2"
+  depends:
+  - "octave (>= 4.4.0)"
   - "pkg"
 ---

--- a/packages/caosdb.yaml
+++ b/packages/caosdb.yaml
@@ -1,0 +1,47 @@
+---
+layout: "package"
+permalink: "caosdb"
+description: >-
+  This package contains utility functions to interact with CaosDB, the open
+  scientific data management toolkit.
+
+  It makes use of libcaosdb,  which must be installed on the
+  system.  libcaosdb can be obtained at https://gitlab.com/caosdb/caosdb-cpplib
+# TODO: Check icon URL
+icon: "https://gitlab.com/caosdb/caosdb-octavelib/-/raw/main/doc/img/caosdb_icon.png"
+links:
+- icon: "far fa-copyright"
+  label: "AGPL-3.0-or-later"
+  url: "https://gitlab.com/caosdb/caosdb-octavelib/-/blob/main/LICENSE.md"
+- icon: "fas fa-rss"
+  label: "news"
+  url: "https://gitlab.com/caosdb/caosdb-octavelib/-/blob/main/CHANGELOG.md"
+- icon: "fas fa-code-branch"
+  label: "repository"
+  url: "https://gitlab.com/caosdb/caosdb-octavelib"
+- icon: "fas fa-book"
+  label: "package documentation"
+  url: "https://docs.indiscale.com/caosdb-octavelib"
+- icon: "fas fa-bug"
+  label: "report a problem"
+  url: "https://gitlab.com/caosdb/caosdb-octavelib/-/issues"
+maintainers:
+- name: "Daniel Hornung"
+  contact: "d.hornung@indiscale.com"
+versions:
+# TODO Update release data
+- id: "0.0.2"
+  date: "2021-xx-xx"
+  sha256: "bff441755f0d68596f2efd027fe637b5b6c52b722ffd6255bdb8a5f34ab4ef2a"
+  url: "https://github.com/gnu-octave/pkg-example/archive/1.1.0.tar.gz"
+  depends:
+  - "octave (>= 4.0.0)"
+  - "pkg"
+- id: "dev"
+  date:
+  sha256:
+  url: "https://gitlab.com/caosdb/caosdb-octavelib/-/archive/dev/caosdb-octavelib-dev.zip"
+  depends:
+  - "octave (>= 4.0.0)"
+  - "pkg"
+---


### PR DESCRIPTION
**Note: This pull request is still WIP, do not merge yet.**

This package contains utility functions to interact with CaosDB, the open scientific data management toolkit.

It makes use of libcaosdb,  which must be installed on the system.  libcaosdb can be obtained at https://gitlab.com/caosdb/caosdb-cpplib