### PR TITLE
fda.yaml: link to v1.0.0 release

### DIFF
--- a/packages/fda.yaml
+++ b/packages/fda.yaml
@@ -24,7 +24,7 @@ versions:
 - id: "1.0.0"
   date: "2018-02-23"
   sha256:
-  url: "https://gitlab.com/kakila/fda/-/archive/master/fda-master.tar.gz"
+  url: "https://gitlab.com/kakila/fda/-/archive/v1.0.0/fda-v1.0.0.tar.gz"
   depends:
   - "octave (>= 4.2.0)"
   - "pkg"

--- a/packages/fda.yaml
+++ b/packages/fda.yaml
@@ -23,7 +23,7 @@ maintainers:
 versions:
 - id: "1.0.0"
   date: "2018-02-23"
-  sha256:
+  sha256: "bc06c351b4cd1426288e0ce00f80009261fab843cb859a5c4f3f2f0507003e60"
   url: "https://gitlab.com/kakila/fda/-/archive/v1.0.0/fda-v1.0.0.tar.gz"
   depends:
   - "octave (>= 4.2.0)"


### PR DESCRIPTION
Rafael Laboissiere from Debian set up releases branch on the repo. updating the url to that release