### PR TITLE
Update statistics-bootstrap 5.3.1.yaml (fixed issue with pkg install of 5.3.0)

### DIFF
--- a/packages/statistics-bootstrap.yaml
+++ b/packages/statistics-bootstrap.yaml
@@ -25,6 +25,13 @@ maintainers:
 - name: "Andrew C. Penn"
   contact: "andy.c.penn@gmail.com"
 versions:
+- id: "5.3.0"
+  date: "2023-08-09"
+  sha256: "f06c1f8ab80574bb02e36c870f9014dd0d761e7288f5805cc999bfcf9aed34b2"
+  url: "https://github.com/gnu-octave/statistics-bootstrap/archive/refs/tags/v5.3.0.tar.gz"
+  depends:
+  - "octave (>= 4.4.0)"
+  - "pkg"
 - id: "5.2.8"
   date: "2023-06-13"
   sha256: "da0b704fcc75b57193e45b55c682974692ce6cd64647b0114a2b73af5b1a55b5"

--- a/packages/statistics-bootstrap.yaml
+++ b/packages/statistics-bootstrap.yaml
@@ -25,10 +25,10 @@ maintainers:
 - name: "Andrew C. Penn"
   contact: "andy.c.penn@gmail.com"
 versions:
-- id: "5.3.0"
+- id: "5.3.1"
   date: "2023-08-09"
-  sha256: "f06c1f8ab80574bb02e36c870f9014dd0d761e7288f5805cc999bfcf9aed34b2"
-  url: "https://github.com/gnu-octave/statistics-bootstrap/archive/refs/tags/v5.3.0.tar.gz"
+  sha256: "3c0b9455bad23d76958c5609cb5237d71ab36f4d2c0f2a272aa57dc08ffb99cb"
+  url: "https://github.com/gnu-octave/statistics-bootstrap/archive/refs/tags/v5.3.1.tar.gz"
   depends:
   - "octave (>= 4.4.0)"
   - "pkg"
@@ -210,7 +210,6 @@ versions:
   sha256:
   url: "https://github.com/gnu-octave/statistics-bootstrap/archive/refs/heads/master.zip"
   depends:
-  - "octave (>= 3.6.0)"
-  - "statistics (>= 1.0.0)"
+  - "octave (>= 4.4.0)"
   - "pkg"
 ---


### PR DESCRIPTION
New functions:
/inst/bootcdf.m
/inst/randtest2.m
/inst/bootlm.m
/inst/param/sampszcalc.m

Removed:
/inst/octave/bootcoeff.m (functionality now in bootlm.m)
/inst/octave/bootemm.m (functionality now in bootlm.m)

Improvements or bug fixes:
small change of behaviour to boot.mex and boot.m when NBOOT is only 1
small changes to bootwild.m and bootbayes.m functions
minor syntax changes to the code in various functions
fixed bug in DESCRIPTION file caused by illegal character