### PR TITLE
Update statistics-resampling.yaml - version 5.5.3

### DIFF
--- a/packages/statistics-resampling.yaml
+++ b/packages/statistics-resampling.yaml
@@ -27,10 +27,10 @@ maintainers:
 - name: "Andrew C. Penn"
   contact: "andy.c.penn@gmail.com"
 versions:
-- id: "5.5.2"
-  date: "2024-01-02"
-  sha256: "910a75310024fe1e2d1d83fd042e27134df9caf4896e35f6407b67c625ea451f"
-  url: "https://github.com/gnu-octave/statistics-resampling/archive/refs/tags/v5.5.2.zip"
+- id: "5.5.3"
+  date: "2024-01-03"
+  sha256: "bd161552548cf0e4c1d332f1557706abd4cb0ab2ff2d7cd281b95e5fc7f7d89c"
+  url: "https://github.com/gnu-octave/statistics-resampling/archive/refs/tags/v5.5.3.zip"
   depends:
   - "octave (>= 4.4.0)"
   - "pkg"
@@ -38,6 +38,13 @@ versions:
   date:
   sha256:
   url: "https://github.com/gnu-octave/statistics-resampling/archive/refs/heads/master.zip"
+  depends:
+  - "octave (>= 4.4.0)"
+  - "pkg"
+- id: "5.5.2"
+  date: "2024-01-02"
+  sha256: "910a75310024fe1e2d1d83fd042e27134df9caf4896e35f6407b67c625ea451f"
+  url: "https://github.com/gnu-octave/statistics-resampling/archive/refs/tags/v5.5.2.zip"
   depends:
   - "octave (>= 4.4.0)"
   - "pkg"


### PR DESCRIPTION
Created relative symbolic links and windows shortcut to folder containing the manual pages (since the symbolic links directly to the manual and readme pages didn't work in windows). Also added information to the readme page advising users that javascript should be enabled for best viewing experience of the manual.