### PR TITLE
Update GitHub actions to newer versions.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       -
         name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       -
@@ -88,10 +88,10 @@ jobs:
     steps:
       -
         name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up Python 3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.x'

--- a/.github/workflows/website_build_deploy.yml
+++ b/.github/workflows/website_build_deploy.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
         with:
@@ -43,7 +43,7 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Get Package Stars
         run: |
           bundle exec ruby ./assets/get_stars.rb
@@ -66,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
GitHub-hosted runners are transitioning from Node.js 16 to Node.js 20. Update to the latest versions of actions to prepare for that change.
See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

`ruby/setup-ruby` is pinned to a commit (instead of a tag). I don't know the reason for that. So, I refrained from changing it.

@siko1056: At some point (when Node.js 16 disappears from GitHub-hosted runners), we probably need to also update that action to a newer version. Do you recall why that action doesn't use a tag? Are there specific tests that need to pass before we can update those actions?
