### PR TITLE
Use dependabot to periodically check for updated Ruby Gems.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    schedule:
+      # Check for updates to Ruby Gems every day
+      interval: 'daily'


### PR DESCRIPTION
Basically the same as #408 but for the Ruby Gems.

@siko1056: I don't know much about web deployment. Would this be helpful? Or more noise than what it's worth?
