### PR TITLE
Create timer.yaml

### DIFF
--- a/packages/timer.yaml
+++ b/packages/timer.yaml
@@ -1,0 +1,34 @@
+---
+layout: "package"
+permalink: "timer/"
+description: >-
+  A class allowing to schedule one or multiple executions of tasks.
+icon:
+links:
+- icon: "far fa-copyright"
+  label: "GPL-3.0-or-later"
+  url: "https://gitlab.com/farhi/octave-timer/blob/main/COPYING"
+- icon: "fas fa-rss"
+  label: "news"
+  url: "https://gitlab.com/farhi/octave-timer/-/blob/main/NEWS?ref_type=heads"
+- icon: "fas fa-code-branch"
+  label: "repository"
+  url: "https://gitlab.com/farhi/octave-timer/"
+- icon: "fas fa-book"
+  label: "package documentation"
+  url: "https://gitlab.com/farhi/octave-timer/"
+- icon: "fas fa-bug"
+  label: "report a problem"
+  url: "https://gitlab.com/farhi/octave-timer/issues"
+maintainers:
+- name: "Emmanuel Farhi"
+  contact:
+versions:
+- id: "0.1.1"
+  date: "2024-04-27"
+  sha256:
+  url: "https://gitlab.com/farhi/octave-timer/-/archive/0.1.1/octave-timer-0.1.1.tar.gz"
+  depends:
+  - "octave (>= 4.0.0)"
+  - "pkg"
+---


### PR DESCRIPTION
This is a package contribution to provide Octave with a Timer object a-la Matlab.
The package has been built in the style of Octave packages, and I hope this is good enough.

Thanks for Octave !
Emmanuel.

PS: I would also appreciate to have support for 'events' in 'classdef' but this is slightly more involved. It looks like the 'meta' package includes events, but these are not retrieved into the class representation. If ever done, a simple Timer could then handle a notify/listen stack for each class. But other lower level solution are probably to be favored.