### PR TITLE
Create hgsetget.yaml

### DIFF
--- a/packages/hgsetget.yaml
+++ b/packages/hgsetget.yaml
@@ -1,0 +1,34 @@
+---
+layout: "package"
+permalink: "hgsetget/"
+description: >-
+  Superclass used to derive handle class with set and get methods.
+icon:
+links:
+- icon: "far fa-copyright"
+  label: "GPL-2.0-or-later"
+  url: "https://gitlab.com/farhi/octave-hgsetget/blob/main/COPYING"
+- icon: "fas fa-rss"
+  label: "news"
+  url: "https://gitlab.com/farhi/octave-hgsetget/-/blob/main/NEWS?ref_type=heads"
+- icon: "fas fa-code-branch"
+  label: "repository"
+  url: "https://gitlab.com/farhi/octave-hgsetget/"
+- icon: "fas fa-book"
+  label: "package documentation"
+  url: "https://gitlab.com/farhi/octave-hgsetget/"
+- icon: "fas fa-bug"
+  label: "report a problem"
+  url: "https://gitlab.com/farhi/octave-hgsetget/issues"
+maintainers:
+- name: "Emmanuel Farhi"
+  contact:
+versions:
+- id: "0.1"
+  date: "2019-11-02"
+  sha256:
+  url: "https://gitlab.com/farhi/octave-hgsetget/-/archive/0.1/octave-hgsetget-0.1.tar.gz"
+  depends:
+  - "octave (>= 4.0.0)"
+  - "pkg"
+---


### PR DESCRIPTION
This is a contribution for Octave to provide the 'hgsetget' superclass which gives 'set' and 'get' methods to all derived classed. 

In recent Matlab releases, this has been renamed as `matlab.mixin.SetGet` Class
- https://fr.mathworks.com/help/matlab/ref/hgsetget.html
- https://fr.mathworks.com/help/matlab/ref/matlab.mixin.setget-class.html

Many thanks for providing Octave, and this package contribution mechanism.
Emmanuel.