### PR TITLE
Add package: dynamicprops.yaml

### DIFF
--- a/packages/dynamicprops.yaml
+++ b/packages/dynamicprops.yaml
@@ -1,0 +1,41 @@
+---
+layout: "package"
+permalink: "dynamicprops/"
+description: >-
+  Matlab-compatible superclass allowing to add new properties dynamically.
+icon:
+links:
+- icon: "far fa-copyright"
+  label: "GPL-2.0-or-later"
+  url: "https://gitlab.com/farhi/octave-dynamicprops/blob/master/COPYING"
+- icon: "fas fa-rss"
+  label: "news"
+  url: "https://gitlab.com/farhi/octave-dynamicprops/releases"
+- icon: "fas fa-code-branch"
+  label: "repository"
+  url: "https://gitlab.com/farhi/octave-dynamicprops/"
+- icon: "fas fa-book"
+  label: "package documentation"
+  url: "https://gitlab.com/farhi/octave-dynamicprops/blob/master/README.md"
+- icon: "fas fa-bug"
+  label: "report a problem"
+  url: "https://gitlab.com/farhi/octave-dynamicprops/issues"
+maintainers:
+- name: "Emmanuel Farhi"
+  contact: "emmanuel.farhi@synchrotron-soleil.fr"
+versions:
+- id: "0.1"
+  date: "2019-11-02"
+  sha256: 
+  url: "https://gitlab.com/farhi/octave-dynamicprops/-/archive/0.1/octave-dynamicprops-0.1.tar.gz"
+  depends:
+  - "octave (>= 4.0.0)"
+  - "pkg"
+- id: "dev"
+  date:
+  sha256:
+  url: "https://gitlab.com/farhi/octave-dynamicprops/archive/master.tar.gz"
+  depends:
+  - "octave (>= 4.0.0)"
+  - "pkg"
+---


### PR DESCRIPTION
Add contribution 'dynamicprops':
- Matlab-compatible superclass allowing to add new properties dynamically.

Dear Octave package maintainers,
here is a contribution for a `dynamicprops` class which works similarly as in Matlab.
- https://fr.mathworks.com/help/matlab/ref/dynamicprops-class.html

I have formatted the documentation in the style of Octave texinfo, and added a test at the end of the `dynamicprops.m` file.

Thanks for your work !
Emmanuel.