### PR TITLE
Add package: hgsetget.yaml

### DIFF
--- a/packages/hgsetget.yaml
+++ b/packages/hgsetget.yaml
@@ -1,0 +1,41 @@
+---
+layout: "package"
+permalink: "hgsetget/"
+description: >-
+  Matlab-compatible superclass used to derive handle class with set and get methods.
+icon:
+links:
+- icon: "far fa-copyright"
+  label: "GPL-2.0-or-later"
+  url: "https://gitlab.com/farhi/octave-hgsetget/blob/master/COPYING"
+- icon: "fas fa-rss"
+  label: "news"
+  url: "https://gitlab.com/farhi/octave-hgsetget/releases"
+- icon: "fas fa-code-branch"
+  label: "repository"
+  url: "https://gitlab.com/farhi/octave-hgsetget/"
+- icon: "fas fa-book"
+  label: "package documentation"
+  url: "https://gitlab.com/farhi/octave-hgsetget/blob/master/README.md"
+- icon: "fas fa-bug"
+  label: "report a problem"
+  url: "https://gitlab.com/farhi/octave-hgsetget/issues"
+maintainers:
+- name: "Emmanuel Farhi"
+  contact: "emmanuel.farhi@synchrotron-soleil.fr"
+versions:
+- id: "0.1"
+  date: "2019-11-02"
+  sha256: 
+  url: "https://gitlab.com/farhi/octave-hgsetget/-/archive/0.1/octave-hgsetget-0.1.tar.gz"
+  depends:
+  - "octave (>= 4.0.0)"
+  - "pkg"
+- id: "dev"
+  date:
+  sha256:
+  url: "https://gitlab.com/farhi/octave-hgsetget/archive/master.tar.gz"
+  depends:
+  - "octave (>= 4.0.0)"
+  - "pkg"
+---

--- a/packages/hgsetget.yaml
+++ b/packages/hgsetget.yaml
@@ -26,7 +26,7 @@ maintainers:
 versions:
 - id: "0.1"
   date: "2019-11-02"
-  sha256: 
+  sha256: "17e6b203b4dc8b29d3c1cc1c875188fa3048d8db4adcc2b46efed8ddcc25747d"
   url: "https://gitlab.com/farhi/octave-hgsetget/-/archive/0.1/octave-hgsetget-0.1.tar.gz"
   depends:
   - "octave (>= 4.0.0)"

--- a/packages/hgsetget.yaml
+++ b/packages/hgsetget.yaml
@@ -2,7 +2,8 @@
 layout: "package"
 permalink: "hgsetget/"
 description: >-
-  Matlab-compatible superclass used to derive handle class with set and get methods.
+  Matlab-compatible superclass used to derive handle class
+  with set and get methods.
 icon:
 links:
 - icon: "far fa-copyright"


### PR DESCRIPTION
Add contribution 'hgsetget':
- Matlab-compatible superclass used to derive handle class with set and get methods.
- https://fr.mathworks.com/help/matlab/ref/hgsetget.html

This class has been renamed in Matlab as `matlab.mixin.SetGet` but is still widely used and supported (April 2024).

I have formatted the documentation in the style of Octave texinfo, and added a test at the end of the `hgsetget.m` file.

Thanks for your work !
Emmanuel.