### PR TITLE
CI: Check if version in package index matches version of installed package

### DIFF
--- a/assets/ci/octave_ci.m
+++ b/assets/ci/octave_ci.m
@@ -99,6 +99,15 @@ function octave_ci (package_name, pkg_index_file)
     exit (1);  # Return test failed.
   end
 
+  step_group_start (["Check: pkg version ", pkg_name_version]);
+  installed_pkg = pkg ("list", package_name);
+  if (! strcmp (__pkg__.(package_name).versions(1).id, ...
+                installed_pkg{1}.version))
+    ## FIXME: Should this fail the CI instead of emitting a warning?
+    step_warning ("Version of installed package doesn't match version in package index");
+  endif
+  step_group_end ("done.");
+
   step_group_start (["Run: pkg load      ", pkg_name_version]);
   pkg ("load", package_name);
   step_group_end ("done.");


### PR DESCRIPTION
Compare the package version in the `.yaml` file with the package version of the installed package (i.e., the `DESCRIPTION` file).
That might help to detect issues like the one in #451 earlier in the CI.

@cbm, @siko1056: This is untested as of now. Is the check correct? And could that be useful?
