### PR TITLE
Retract Symbolic v3.2.0

### DIFF
--- a/packages/symbolic.yaml
+++ b/packages/symbolic.yaml
@@ -43,15 +43,6 @@ versions:
   - "pkg"
   ubuntu2204:
   - "python3-sympy"
-- id: "3.2.0"
-  date: "2024-05-13"
-  sha256: "3fe10d2f868a0bc375d8f3c839f7f89896d5476dc0e49a6802ac4a53d42d7c17"
-  url: "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/symbolic-3.2.0.tar.gz"
-  depends:
-  - "octave (>= 5.1.0)"
-  - "pkg"
-  ubuntu2204:
-  - "python3-sympy"
 - id: "3.1.1"
   date: "2023-03-19"
   sha256: "988d2f356ea63488ad8d1c39434760ac24ee2af4efae896c1fd93a5df934532b"


### PR DESCRIPTION
Wrong tarball was shipped; use v3.2.1 instead

- - - -

Meta question: is this the correct way to retract a release?  I have already made a v3.2.1, so I'm just deleting this from the record for `pkg`.  

Then I'll remove the tarball from sourceforge and delete the release from https://github.com/gnu-octave/symbolic/releases

@mmuetzel and @siko1056 does that sound right?  Or should I start a thread about this on octave.discourse.group?