### PR TITLE
Update geographiclib.yaml: release 2.3

### DIFF
--- a/packages/geographiclib.yaml
+++ b/packages/geographiclib.yaml
@@ -12,7 +12,7 @@ description: >-
   (d) Geoid lookup, egm84, egm96, egm2008 geoids supported;
   (e) Geometric transformations, geocentric, local cartesian;
   (f) Great ellipse, direct, inverse, area calculations;
-  (g) A class to solve problems on a triaxial ellipsoid.
+  (g) Geodesics and coordinate conversions on a triaxial ellipsoid.
 icon: "https://avatars.githubusercontent.com/u/86781918"
 links:
 - icon: "far fa-copyright"
@@ -34,6 +34,13 @@ maintainers:
 - name: "Charles Karney"
   contact: "karney@alum.mit.edu"
 versions:
+- id: "2.3"
+  date: "2024-07-09"
+  sha256: "af72f05911c0f98076058a6df69734087ecc95f54acd9cbf1e8a1e9cd20d1342"
+  url: "https://sourceforge.net/projects/geographiclib/files/distrib-Octave/geographiclib-octave-2.3.tar.gz"
+  depends:
+  - "octave (>= 4.0.0)"
+  - "pkg"
 - id: "2.2"
   date: "2024-04-09"
   sha256: "807d7eeeb184b3690e86fa4cd5cc956c45a609009458931adb8af1c11a278d02"


### PR DESCRIPTION
Bug fixes and various improvements in routines for triaxial ellipsoids.

See [the NEWS file](https://github.com/geographiclib/geographiclib-octave/blob/main/NEWS) for details.