### PR TITLE
Prepare image-acquisition 0.2.6 release

### DIFF
--- a/packages/image-acquisition.yaml
+++ b/packages/image-acquisition.yaml
@@ -31,4 +31,7 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
+  ubuntu2204:
+  - "libv4l-dev"
+  - "libfltk1.1-dev"
 ---

--- a/packages/image-acquisition.yaml
+++ b/packages/image-acquisition.yaml
@@ -26,7 +26,7 @@ maintainers:
 versions:
 - id: "0.2.6"
   date: "2024-08-31"
-  sha256:
+  sha256: "51e87093af0667f33858be4cdc617efa608f520dccd3c63482474edfaff284d2"
   url: "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/image-acquisition-0.2.6.tar.gz"
   depends:
   - "octave (>= 3.8.0)"


### PR DESCRIPTION
Bugfix release
- Octave version >= 6 removed error_state. Bug #63136)
- Ignore v4l2 Metadata Interface devices in imaqhwinfo.
