### PR TITLE
Update secs2d.yaml URL

### DIFF
--- a/packages/secs2d.yaml
+++ b/packages/secs2d.yaml
@@ -21,7 +21,7 @@ versions:
 - id: "0.0.8"
   date: "2009-05-06"
   sha256:
-  url: "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Old%20Monolithic%20Releases/R2009-05-08/secs1d-0.0.8.tar.gz"
+  url: "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Old%20Monolithic%20Releases/R2009-05-08/secs2d-0.0.8.tar.gz"
   depends:
   - "octave (>= 2.9.17)"
   - "pkg"

--- a/packages/secs2d.yaml
+++ b/packages/secs2d.yaml
@@ -21,7 +21,7 @@ versions:
 - id: "0.0.8"
   date: "2009-05-06"
   sha256:
-  url: "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/secs2d-0.0.8.tar.gz"
+  url: "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Old%20Monolithic%20Releases/R2009-05-08/secs1d-0.0.8.tar.gz"
   depends:
   - "octave (>= 2.9.17)"
   - "pkg"

--- a/packages/secs2d.yaml
+++ b/packages/secs2d.yaml
@@ -20,7 +20,7 @@ maintainers:
 versions:
 - id: "0.0.8"
   date: "2009-05-06"
-  sha256:
+  sha256: "4f1945e3324487f08b8d7ef7ead55b6d29595d435472b52d83b358934a6d45f7"
   url: "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Old%20Monolithic%20Releases/R2009-05-08/secs2d-0.0.8.tar.gz"
   depends:
   - "octave (>= 2.9.17)"


### PR DESCRIPTION
Previous URL was not valid, new URL taken from https://octave.sourceforge.io/secs2d/.