### PR TITLE
Update octave_zstd Fedora dependency

### DIFF
--- a/packages/octave_zstd.yaml
+++ b/packages/octave_zstd.yaml
@@ -35,4 +35,8 @@ versions:
   - "octave (>= 8.0.0)"
   - "pkg"
   - "octave_tar (>= 1.0.1)"
+  fedora40:
+  - "libzstd"
+  - "libzstd-devel"
+  - "libzstd-static"
 ---


### PR DESCRIPTION
Fedora：
$ sudo dnf install libzstd libzstd-devel libzstd-static