### PR TITLE
Update image.yaml - Image package 2.16.1

### DIFF
--- a/packages/image.yaml
+++ b/packages/image.yaml
@@ -30,6 +30,13 @@ maintainers:
 - name: "Avinoam Kalma"
   contact:
 versions:
+- id: "2.16.1"
+  date: "2025-05-04"
+  sha256: "34a84f755261f6c8d882d08b07567464ea25dc1515072ef6886f2b26ebf6f0a7"
+  url: "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/image-2.16.1.tar.gz"
+  depends:
+  - "octave (>= 7.1.0)"
+  - "pkg"
 - id: "2.16.0"
   date: "2025-03-03"
   sha256: "9bb26cca58eb1fbedfb3f84e3d2e7e1eeb5e16d7ebe3235b7c107d94f58d1417"


### PR DESCRIPTION
** image 2.16.1 is a patch release.

 ** The function std2 now checks to ensure inputs are numeric and converts
    image data to double before passing to std().  Previous versions of the
    function could return incorrect values for integer type image data due
    to integer underflow and/or rounding.  Note that this conversion to
    double can run into accuracy limitations for 64-bit integer data types
    where the conversion can exceed the value of flintmax("double").  The
    function also now accepts complex data types (bug #67031).

 ** connectivity.cc: adding special treatment if ndims or numel equal 0
    to avoid heap-buffer-overflow crash (bug #66918).

 ** Add 'reflect' padding option to imfilter (bug #52119).

 ** Fix typos in the documentation of edge.m, entropy.m entropyfilt.m,
    imboxfilt.m imagaussfilt.m & hough.m