### PR TITLE
tablicious 0.4.5 + master->main branch rename

### DIFF
--- a/packages/tablicious.yaml
+++ b/packages/tablicious.yaml
@@ -4,11 +4,11 @@ permalink: "tablicious/"
 description: >-
   Matlab-compatible Octave table class for storing tabular/relational data.
   Similar to R and Python Pandas DataFrames.
-icon: "https://raw.githubusercontent.com/apjanke/octave-tablicious/master/assets/Tablicious-640.png"
+icon: "https://raw.githubusercontent.com/apjanke/octave-tablicious/main/assets/Tablicious-640.png"
 links:
 - icon: "far fa-copyright"
   label: "GPL-3.0-or-later"
-  url: "https://github.com/apjanke/octave-tablicious/blob/master/COPYING"
+  url: "https://github.com/apjanke/octave-tablicious/blob/main/COPYING"
 - icon: "fas fa-rss"
   label: "news"
   url: "https://github.com/apjanke/octave-tablicious/releases"
@@ -17,7 +17,7 @@ links:
   url: "https://github.com/apjanke/octave-tablicious/"
 - icon: "fas fa-book"
   label: "package documentation"
-  url: "https://github.com/apjanke/octave-tablicious/blob/master/README.md"
+  url: "https://github.com/apjanke/octave-tablicious/blob/main/README.md"
 - icon: "fas fa-bug"
   label: "report a problem"
   url: "https://github.com/apjanke/octave-tablicious/issues"
@@ -107,7 +107,7 @@ versions:
 - id: "dev"
   date:
   sha256:
-  url: "https://github.com/apjanke/octave-tablicious/archive/master.tar.gz"
+  url: "https://github.com/apjanke/octave-tablicious/archive/main.tar.gz"
   depends:
   - "octave (>= 7.0.0)"
   - "pkg"


### PR DESCRIPTION
Tablicious release 0.4.5. Also reflect its repo's renaming branch `master` to `main`, which happened a while back.