### PR TITLE
Update image.yaml

### DIFF
--- a/packages/image.yaml
+++ b/packages/image.yaml
@@ -30,6 +30,13 @@ maintainers:
 - name: "Avinoam Kalma"
   contact:
 versions:
+- id: "2.18.0"
+  date: "2025-08-19"
+  sha256: "d87af2b098a03b3fe78d05fe623cff49765f87251c0090769e214bbbc6569a00"
+  url: "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/image-2.18.0.tar.gz"
+  depends:
+  - "octave (>= 7.2.0)"
+  - "pkg"
 - id: "2.16.1"
   date: "2025-05-04"
   sha256: "34a84f755261f6c8d882d08b07567464ea25dc1515072ef6886f2b26ebf6f0a7"


### PR DESCRIPTION
Image Package 2.18.0:

 Summary of important user-visible changes for image 2.18.0 (2025/08/19):
-------------------------------------------------------------------------

** Octave version 7.2.0 is now the minimum requirement,
    since validateatribute which is used in some new functions,
    fails on 7.1.0

 ** graycomatrix have been re-written to be MATLAB compatible.
    previous version was renamed to graycomatrix_old (bug #38087)

 ** Fixing filter implementation in iradon (bug #59773)

 ** Add Lancsoz2 & Lancsoz3 interpolation for imresize (bug #62099)

 ** Fix (again) imresize when there is anti-alising by adding weight
    normalization (bug #63560)

 ** Fix Makefile so that it will not use GNU extensions for grep
    (bug #66829)

 ** The following functions are new:

    adaptthresh             imbilatfilt           imbinarize
    insertText