### PR TITLE
Update geographiclib.yaml: release 2.4

### DIFF
--- a/packages/geographiclib.yaml
+++ b/packages/geographiclib.yaml
@@ -34,6 +34,13 @@ maintainers:
 - name: "Charles Karney"
   contact: "karney@alum.mit.edu"
 versions:
+- id: "2.4"
+  date: "2025-08-21"
+  sha256: "d35910648f68a918e45c5b0566bfab820df40bed300ada534eeff57761f07952"
+  url: "https://sourceforge.net/projects/geographiclib/files/distrib-Octave/geographiclib-octave-2.4.tar.gz"
+  depends:
+  - "octave (>= 4.0.0)"
+  - "pkg"
 - id: "2.3.3"
   date: "2025-02-17"
   sha256: "17e26be19b4aa528539a932043e6eb72e0a72e138478e7f8295bef2dda5db3b6"


### PR DESCRIPTION
Version 2.4 (released 2025-08-21)
  * Fix bug in geoddistance for very prolate ellipsoids.
  * Fix bug in triaxial.elliptocart2 for biaxial poles.
  * Minor documentation fixes.
