### PR TITLE
Add function reference to mboct-*-pkg

### DIFF
--- a/packages/mboct-fem-pkg.yaml
+++ b/packages/mboct-fem-pkg.yaml
@@ -22,7 +22,7 @@ links:
   url: "https://github.com/octave-user/mboct-fem-pkg"
 - icon: "fas fa-th-list"
   label: "function reference"
-  url: "https://octave-user.github.io/mboct-fem-pkg/mboct-fem-pkg/overview.html"
+  url: "https://octave-user.github.io/mboct-fem-pkg/mboct-fem-pkg"
 - icon: "fas fa-bug"
   label: "report a problem"
   url: "https://github.com/octave-user/mboct-fem-pkg/issues"

--- a/packages/mboct-mbdyn-pkg.yaml
+++ b/packages/mboct-mbdyn-pkg.yaml
@@ -19,7 +19,7 @@ links:
   url: "https://github.com/octave-user/mboct-mbdyn-pkg"
 - icon: "fas fa-th-list"
   label: "function reference"
-  url: "https://octave-user.github.io/mboct-mbdyn-pkg/mboct-mbdyn-pkg/overview.html"  
+  url: "https://octave-user.github.io/mboct-mbdyn-pkg/mboct-mbdyn-pkg"
 - icon: "fas fa-bug"
   label: "report a problem"
   url: "https://github.com/octave-user/mboct-mbdyn-pkg/issues"

--- a/packages/mboct-numerical-pkg.yaml
+++ b/packages/mboct-numerical-pkg.yaml
@@ -19,7 +19,7 @@ links:
   url: "https://github.com/octave-user/mboct-numerical-pkg"
 - icon: "fas fa-th-list"
   label: "function reference"
-  url: "https://octave-user.github.io/mboct-numerical-pkg/mboct-numerical-pkg/overview.html"  
+  url: "https://octave-user.github.io/mboct-numerical-pkg/mboct-numerical-pkg"
 - icon: "fas fa-bug"
   label: "report a problem"
   url: "https://github.com/octave-user/mboct-numerical-pkg/issues"

--- a/packages/mboct-octave-pkg.yaml
+++ b/packages/mboct-octave-pkg.yaml
@@ -19,7 +19,7 @@ links:
   url: "https://github.com/octave-user/mboct-octave-pkg"
 - icon: "fas fa-th-list"
   label: "function reference"
-  url: "https://octave-user.github.io/mboct-octave-pkg/mboct-octave-pkg/overview.html"
+  url: "https://octave-user.github.io/mboct-octave-pkg/mboct-octave-pkg"
 - icon: "fas fa-bug"
   label: "report a problem"
   url: "https://github.com/octave-user/mboct-octave-pkg/issues"


### PR DESCRIPTION
Dear GNU-Octave developers,

This pull request adds a valid function reference to all "mboct-*-pkg" packages.

Best regards,
Reinhard Resch