### PR TITLE
Update fxp.yaml

### DIFF
--- a/packages/fxp.yaml
+++ b/packages/fxp.yaml
@@ -32,6 +32,22 @@ maintainers:
   contact: "ahmed.shahein@vlsi-design.org"
 
 versions:
+- id: "3.0.1"
+  date: "2026-04-12"
+  sha256: "56c2bc4a25e4d455dd893a3d3b35b0a8c1cdeaf8fc348784706085751ad9d952"
+  url: >-
+    https://github.com/ahmedshahein/pkg-fxp/archive/refs/tags/3.0.1.tar.gz
+  depends:
+  - "octave (>= 5.2.0)"
+  - "pkg"
+- id: "3.0.0"
+  date: "2026-04-06"
+  sha256: "2b8280f3fb7d8f96a4f121085be65ed01a84d76bf3ede6639d5b83f6366c7a62"
+  url: >-
+    https://github.com/ahmedshahein/pkg-fxp/archive/refs/tags/3.0.0.tar.gz
+  depends:
+  - "octave (>= 5.2.0)"
+  - "pkg"
 - id: "2.0.0"
   date: "2026-03-26"
   sha256: "491c4001390d71da2412d11c43b13f0988712242df83bb1b9efdc80e6d3fce6a"


### PR DESCRIPTION
Minor bug fix in the DESCRIPTION file to resolve installation path using "pkg install -forge fxp" by appending the correct path instead of always using 1.0.1 in the installation path. 
Release 3.0.0 had major updates:
Added comprehensive help, “help fxp.
Added self-checking testing based on 28 tests, “test fxp”. 
Bug fix in rounding scheme “fix – round towards zero”.