### PR TITLE
bioinfo: Fix checksum of tarball for release 0.2.2

### DIFF
--- a/packages/bioinfo.yaml
+++ b/packages/bioinfo.yaml
@@ -32,7 +32,7 @@ versions:
   - "pkg"
 - id: "0.2.2"
   date: "2021-07-28"
-  sha256: "423ec68a03077ca534ee1a2c29bfa4253d913731c7e6fd6d10faa00d7022d648"
+  sha256: "54c69dd677929fae9a4ed2f5fc47fb460204d92bf5a63b7cfae34c3f6095b768"
   url: "https://github.com/schloegl/octmat-bioinfo/archive/refs/tags/bioinfo-0.2.2.tar.gz"
   depends:
   - "octave (>= 3.0.0)"


### PR DESCRIPTION
I accidentally pasted the wrong checksum in #736.
