### PR TITLE
CI: Elevate warning to error if release version does not match.

### DIFF
--- a/assets/ci/octave_ci.m
+++ b/assets/ci/octave_ci.m
@@ -21,6 +21,9 @@ function octave_ci (package_name, pkg_index_file)
     return;
   endif
 
+  ## Set to true to indicate that tests failed but still continue.
+  tests_failed = false;
+
   ## Package name should be lower case, but do not be pedantic.
   package_name = tolower (package_name);
 
@@ -103,6 +106,7 @@ function octave_ci (package_name, pkg_index_file)
   installed_pkg = pkg ("list", package_name);
   if (! strcmp (pkg_info.id, installed_pkg{1}.version))
     step_error ("Version of installed package does not match version in package index");
+    tests_failed = true;
   endif
   step_group_end ("done.");
 
@@ -140,6 +144,10 @@ function octave_ci (package_name, pkg_index_file)
   step_group_start ("Show: fntests.log");
   type (fullfile (test_dir, "fntests.log"));
   step_group_end ("done.");
+
+  if (tests_failed)
+    exit (1);
+  endif
 
 endfunction
 

--- a/assets/ci/octave_ci.m
+++ b/assets/ci/octave_ci.m
@@ -102,8 +102,7 @@ function octave_ci (package_name, pkg_index_file)
   step_group_start (["Check: pkg version ", pkg_name_version]);
   installed_pkg = pkg ("list", package_name);
   if (! strcmp (pkg_info.id, installed_pkg{1}.version))
-    ## FIXME: Should this fail the CI instead of emitting a warning?
-    step_warning ("Version of installed package doesn't match version in package index");
+    step_error ("Version of installed package does not match version in package index");
   endif
   step_group_end ("done.");
 


### PR DESCRIPTION
Also, avoid contraction in message.

Apparently, updating the `DESCRIPTION` file for a package release is an easily missed step. At least, that was happening a couple of times in the last few weeks.
Failing the CI in that case might raise awareness for that step.

I'll leave this open for at least a week or so and wait for feedback before merging.
If there is earlier agreement that this is something that we should do, we can also merge earlier.
