### PR TITLE
Migrate from Ubuntu 22.04 to 26.04 LTS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,7 +274,7 @@ versions:
     [Octave manual](https://octave.org/doc/v7.1.0/The-DESCRIPTION-File.html)
     "DESCRIPTION"-file "Depends" section.
 
-  - `ubuntu2204`: list of Ubuntu 22.04 (LTS) dependency strings.
+  - `ubuntu2604`: list of Ubuntu 26.04 (LTS) dependency strings.
 
     A dependency string looks like `"libopenblas-dev"`.
     The corresponding Ubuntu package must be available at
@@ -286,7 +286,7 @@ versions:
     [Octave Docker image](https://github.com/gnu-octave/docker/blob/main/build-octave-7.docker).
     Try to keep the list as short as possible.
 
-  - `ubuntu2204w`: list of Ubuntu 22.04 (LTS) weak dependency strings.
+  - `ubuntu2604w`: list of Ubuntu 26.04 (LTS) weak dependency strings.
 
     [Term explanation of weak dependency](https://docs.fedoraproject.org/en-US/packaging-guidelines/WeakDependencies/#:~:text=Weak%20dependencies%20allow%20smaller%20minimal,or%20community%2Dmysql%20vs%20mariadb.)
 

--- a/_layouts/package.html
+++ b/_layouts/package.html
@@ -106,10 +106,10 @@ layout: default
             </span>
           {%- endfor -%}
         </li>
-        {%- if v.ubuntu2204 -%}
+        {%- if v.ubuntu2604 -%}
         <li>
-          <b>Ubuntu 22.04:</b>
-          {%- for dep in v.ubuntu2204 -%}
+          <b>Ubuntu 26.04:</b>
+          {%- for dep in v.ubuntu2604 -%}
             &nbsp;&nbsp;&nbsp;&nbsp;
             <span style="white-space: nowrap;">
               <a href="https://packages.ubuntu.com/jammy/{{ dep }}">{{ dep }}</a>
@@ -117,10 +117,10 @@ layout: default
           {%- endfor -%}
         </li>
         {%- endif -%}
-        {%- if v.ubuntu2204w -%}
+        {%- if v.ubuntu2604w -%}
         <li>
-          <b>Ubuntu 22.04 (Weak Dependency(ies)):</b>
-          {%- for dep in v.ubuntu2204w -%}
+          <b>Ubuntu 26.04 (Weak Dependency(ies)):</b>
+          {%- for dep in v.ubuntu2604w -%}
             &nbsp;&nbsp;&nbsp;&nbsp;
             <span style="white-space: nowrap;">
               <a href="https://packages.ubuntu.com/jammy/{{ dep }}">{{ dep }}</a>

--- a/assets/ci/octave_ci.m
+++ b/assets/ci/octave_ci.m
@@ -59,15 +59,15 @@ function octave_ci (package_name, pkg_index_file)
   cd (test_dir);
 
   step_group_start ("Resolve package dependencies");
-  [ubuntu2204, pkgs] = resolve_deps (__pkg__, {package_name});
+  [ubuntu2604, pkgs] = resolve_deps (__pkg__, {package_name});
   step_group_end ("done.");
 
-  if (! isempty (ubuntu2204))
-    step_group_start ("Install Ubuntu 22.04 dependencies");
+  if (! isempty (ubuntu2604))
+    step_group_start ("Install Ubuntu 26.04 dependencies");
     system ("sudo apt-get update");
     ## Avoid input prompts during package installation (e.g., for tzdata)
     system (["sudo DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC ", ...
-             "apt-get install --yes apt-utils ", strjoin(ubuntu2204)]);
+             "apt-get install --yes apt-utils ", strjoin(ubuntu2604)]);
     step_group_end ("done.");
   endif
 
@@ -210,7 +210,7 @@ function pkg_install_sha256_check (pkg_version, test_dir)
 endfunction
 
 
-function [ubuntu2204, pkgs] = resolve_deps (__pkg__, stack);
+function [ubuntu2604, pkgs] = resolve_deps (__pkg__, stack);
 ## Simple resolver function.
 ##
 ## Only considers the newest version of a package.
@@ -219,7 +219,7 @@ function [ubuntu2204, pkgs] = resolve_deps (__pkg__, stack);
 ##
 
   pkgs = {};
-  ubuntu2204 = {};
+  ubuntu2604 = {};
   p = get_first_version (__pkg__, stack{end});
 
   if (isfield (p, "depends"))
@@ -233,24 +233,24 @@ function [ubuntu2204, pkgs] = resolve_deps (__pkg__, stack);
       if (any (strcmp (pkgs{i}, stack)))
         error ("resolve_deps: circular dependency detected.");
       endif
-      [new_ubuntu2204, new_pkgs] = resolve_deps (__pkg__, [stack, pkgs(i)]);
-      ubuntu2204 = [reshape(ubuntu2204, [], 1); reshape(new_ubuntu2204, [], 1)];
+      [new_ubuntu2604, new_pkgs] = resolve_deps (__pkg__, [stack, pkgs(i)]);
+      ubuntu2604 = [reshape(ubuntu2604, [], 1); reshape(new_ubuntu2604, [], 1)];
       pkgs = [reshape(pkgs, [], 1); reshape(new_pkgs, [], 1)];
     endfor
   endif
 
-  if (isfield (p, "ubuntu2204") && ! isempty (p.ubuntu2204))
-    new_ubuntu2204 = p.ubuntu2204;
-    for i = 1:length (new_ubuntu2204)
+  if (isfield (p, "ubuntu2604") && ! isempty (p.ubuntu2604))
+    new_ubuntu2604 = p.ubuntu2604;
+    for i = 1:length (new_ubuntu2604)
       ## Ubuntu/Debian package name must consist only of lower case letters
       ## (a-z), digits (0-9), plus (+) and minus (-) signs, and periods (.).
-      m = regexp (new_ubuntu2204{i}, '[a-z0-9\+\-\.]*', "match");
-      if ((length (m) ~= 1) || ~strcmp (m{1}, new_ubuntu2204{i}))
-        error ("resolve_deps: invalid Ubuntu 22.04 package %s.", ...
-          new_ubuntu2204{i});
+      m = regexp (new_ubuntu2604{i}, '[a-z0-9\+\-\.]*', "match");
+      if ((length (m) ~= 1) || ~strcmp (m{1}, new_ubuntu2604{i}))
+        error ("resolve_deps: invalid Ubuntu 26.04 package %s.", ...
+          new_ubuntu2604{i});
       endif
     endfor
-    ubuntu2204 = [ubuntu2204; reshape(new_ubuntu2204, [], 1)];
+    ubuntu2604 = [ubuntu2604; reshape(new_ubuntu2604, [], 1)];
   endif
 
 endfunction

--- a/packages/apa.yaml
+++ b/packages/apa.yaml
@@ -38,7 +38,7 @@ versions:
   depends:
   - "octave (>= 9.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libmpfr-dev"
 - id: "1.1.0"
   date: "2026-03-02"
@@ -47,7 +47,7 @@ versions:
   depends:
   - "octave (>= 9.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libmpfr-dev"
 - id: "1.0.0"
   date: "2021-11-22"
@@ -56,7 +56,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libmpfr-dev"
 - id: "dev"
   date:
@@ -65,6 +65,6 @@ versions:
   depends:
   - "octave (>= 9.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libmpfr-dev"
 ---

--- a/packages/audio.yaml
+++ b/packages/audio.yaml
@@ -34,7 +34,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "librtmidi-dev"
 - id: "2.0.10"
   date: "2026-01-25"
@@ -43,7 +43,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "librtmidi-dev"
 - id: "2.0.9"
   date: "2024-09-23"
@@ -52,7 +52,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "librtmidi-dev"
 - id: "2.0.8"
   date: "2023-10-02"
@@ -61,7 +61,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "librtmidi-dev"
 - id: "2.0.7"
   date: "2023-07-26"
@@ -70,7 +70,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "librtmidi-dev"
 - id: "2.0.6"
   date: "2023-07-20"
@@ -79,7 +79,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "librtmidi-dev"
 - id: "2.0.5"
   date: "2022-07-20"
@@ -88,7 +88,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "librtmidi-dev"
 - id: "2.0.4"
   date: "2021-12-05"
@@ -97,7 +97,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "librtmidi-dev"
 - id: "2.0.3"
   date: "2021-10-22"
@@ -106,7 +106,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "librtmidi-dev"
 - id: "2.0.2"
   date: "2020-10-13"
@@ -115,7 +115,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "librtmidi-dev"
 - id: "2.0.1"
   date: "2020-05-08"
@@ -124,6 +124,6 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "librtmidi-dev"
 ---

--- a/packages/biosig.yaml
+++ b/packages/biosig.yaml
@@ -28,7 +28,7 @@ versions:
   depends:
   - "octave (>= 3.2.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libbiosig-dev"
 - id: "3.9.4"
   date: "2026-03-06"
@@ -37,7 +37,7 @@ versions:
   depends:
   - "octave (>= 3.2.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libbiosig-dev"
 - id: "2.5.2"
   date: "2023-07-18"
@@ -46,7 +46,7 @@ versions:
   depends:
   - "octave (>= 3.2.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libbiosig-dev"
 - id: "2.5.1"
   date: "2023-07-18"
@@ -55,7 +55,7 @@ versions:
   depends:
   - "octave (>= 3.2.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libbiosig-dev"
 - id: "2.5.0"
   date: "2023-02-05"
@@ -64,7 +64,7 @@ versions:
   depends:
   - "octave (>= 3.2.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libbiosig-dev"
 - id: "2.4.3"
   date: "2022-10-08"
@@ -73,7 +73,7 @@ versions:
   depends:
   - "octave (>= 3.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libbiosig-dev"
 - id: "2.4.2"
   date: "2022-06-21"
@@ -82,7 +82,7 @@ versions:
   depends:
   - "octave (>= 3.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libbiosig-dev"
 - id: "2.4.1"
   date: "2022-04-23"
@@ -91,7 +91,7 @@ versions:
   depends:
   - "octave (>= 3.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libbiosig-dev"
 - id: "2.4.0"
   date: "2022-03-19"
@@ -100,7 +100,7 @@ versions:
   depends:
   - "octave (>= 3.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libbiosig-dev"
 - id: "dev"
   date:
@@ -109,6 +109,6 @@ versions:
   depends:
   - "octave (>= 3.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libbiosig-dev"
 ---

--- a/packages/cfitsio.yaml
+++ b/packages/cfitsio.yaml
@@ -31,7 +31,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libcfitsio-dev"
 - id: "0.0.7"
   date: "2024-09-23"
@@ -40,7 +40,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libcfitsio-dev"
 - id: "0.0.6"
   date: "2023-12-20"
@@ -49,7 +49,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libcfitsio-dev"
 - id: "0.0.5"
   date: "2023-06-23"
@@ -58,7 +58,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libcfitsio-dev"
 - id: "0.0.4"
   date: "2022-09-21"
@@ -67,7 +67,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libcfitsio-dev"
 - id: "0.0.3"
   date: "2022-06-28"
@@ -76,7 +76,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libcfitsio-dev"
 - id: "0.0.2"
   date: "2022-04-27"
@@ -85,7 +85,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libcfitsio-dev"
 - id: "0.0.1"
   date: "2022-04-26"
@@ -94,6 +94,6 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libcfitsio-dev"
 ---

--- a/packages/database.yaml
+++ b/packages/database.yaml
@@ -35,6 +35,6 @@ versions:
   - "octave (>= 4.0.0)"
   - "struct (>= 1.0.12)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libpq-dev"
 ---

--- a/packages/dicom.yaml
+++ b/packages/dicom.yaml
@@ -37,7 +37,7 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libgdcm-dev"
 - id: "0.7.1"
   date: "2026-01-06"
@@ -46,7 +46,7 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libgdcm-dev"
 - id: "0.6.1"
   date: "2024-07-24"
@@ -55,7 +55,7 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libgdcm-dev"
 - id: "0.6.0"
   date: "2023-12-22"
@@ -64,7 +64,7 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libgdcm-dev"
 - id: "0.5.1"
   date: "2022-11-21"
@@ -73,7 +73,7 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libgdcm-dev"
 - id: "0.5.0"
   date: "2022-06-30"
@@ -82,7 +82,7 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libgdcm-dev"
 - id: "0.4.1"
   date: "2022-02-22"
@@ -91,7 +91,7 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libgdcm-dev"
 - id: "0.4.0"
   date: "2020-09-04"
@@ -100,7 +100,7 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libgdcm-dev"
 - id: "0.3.0"
   date: "2020-02-27"
@@ -109,6 +109,6 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libgdcm-dev"
 ---

--- a/packages/image-acquisition.yaml
+++ b/packages/image-acquisition.yaml
@@ -31,7 +31,7 @@ versions:
   depends:
   - "octave (>= 5.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libv4l-dev"
   - "libfltk1.3-dev"
 - id: "0.3.2"
@@ -41,7 +41,7 @@ versions:
   depends:
   - "octave (>= 5.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libv4l-dev"
   - "libfltk1.3-dev"
 - id: "0.3.1"
@@ -51,7 +51,7 @@ versions:
   depends:
   - "octave (>= 5.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libv4l-dev"
   - "libfltk1.3-dev"
 - id: "0.3.0"
@@ -61,7 +61,7 @@ versions:
   depends:
   - "octave (>= 5.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libv4l-dev"
   - "libfltk1.3-dev"
 ---

--- a/packages/interval.yaml
+++ b/packages/interval.yaml
@@ -47,7 +47,7 @@ versions:
   depends:
   - "octave (>= 4.4.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libmpfr-dev"
 - id: "3.2.1"
   date: "2022-01-28"
@@ -56,7 +56,7 @@ versions:
   depends:
   - "octave (>= 4.2.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libmpfr-dev"
 - id: "3.2.0"
   date: "2018-07-01"
@@ -65,6 +65,6 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libmpfr-dev"
 ---

--- a/packages/joystick.yaml
+++ b/packages/joystick.yaml
@@ -31,7 +31,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libsdl2-dev"
 - id: "0.0.3"
   date: "2023-10-12"
@@ -40,7 +40,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libsdl2-dev"
 - id: "0.0.2"
   date: "2022-09-12"
@@ -49,7 +49,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libsdl2-dev"
 - id: "0.0.1"
   date: "2022-02-22"
@@ -58,6 +58,6 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libsdl2-dev"
 ---

--- a/packages/mapping.yaml
+++ b/packages/mapping.yaml
@@ -33,7 +33,7 @@ versions:
   - "io (>= 2.2.7)"
   - "geometry (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libgdal-dev"
 - id: "1.4.2"
   date: "2022-02-20"

--- a/packages/mboct-fem-pkg.yaml
+++ b/packages/mboct-fem-pkg.yaml
@@ -40,7 +40,7 @@ versions:
   - "mboct-octave-pkg (>=0.1.0)"
   - "mboct-numerical-pkg (>=0.1.0)"
   - "mboct-mbdyn-pkg (>=0.1.0)"
-  ubuntu2204:
+  ubuntu2604:
   - "libmkl-full-dev"
   - "libmetis-dev"
   - "libgtest-dev"
@@ -56,7 +56,7 @@ versions:
   - "mboct-octave-pkg (>=0.1.0)"
   - "mboct-numerical-pkg (>=0.1.0)"
   - "mboct-mbdyn-pkg (>=0.1.0)"
-  ubuntu2204:
+  ubuntu2604:
   - "libmkl-full-dev"
   - "libmetis-dev"
   - "libgtest-dev"
@@ -72,7 +72,7 @@ versions:
   - "mboct-octave-pkg (>=0.1.0)"
   - "mboct-numerical-pkg (>=0.1.0)"
   - "mboct-mbdyn-pkg (>=0.1.0)"
-  ubuntu2204:
+  ubuntu2604:
   - "libmkl-full-dev"
   - "libmetis-dev"
   - "libgtest-dev"

--- a/packages/mboct-mbdyn-pkg.yaml
+++ b/packages/mboct-mbdyn-pkg.yaml
@@ -37,7 +37,7 @@ versions:
   - "mboct-octave-pkg (>=0.1.0)"
   - "mboct-numerical-pkg (>=0.1.0)"
   - "nurbs (>=1.3)"
-  ubuntu2204:
+  ubuntu2604:
   - "libmkl-full-dev"
   - "libmetis-dev"
   - "libgtest-dev"
@@ -52,7 +52,7 @@ versions:
   - "mboct-octave-pkg (>=0.1.0)"
   - "mboct-numerical-pkg (>=0.1.0)"
   - "nurbs (>=1.3)"
-  ubuntu2204:
+  ubuntu2604:
   - "libmkl-full-dev"
   - "libmetis-dev"
   - "libgtest-dev"
@@ -67,7 +67,7 @@ versions:
   - "mboct-octave-pkg (>=0.1.0)"
   - "mboct-numerical-pkg (>=0.1.0)"
   - "nurbs (>=1.3)"
-  ubuntu2204:
+  ubuntu2604:
   - "libmkl-full-dev"
   - "libmetis-dev"
   - "libgtest-dev"

--- a/packages/mboct-numerical-pkg.yaml
+++ b/packages/mboct-numerical-pkg.yaml
@@ -35,7 +35,7 @@ versions:
   - "octave (>= 5.1.0)"
   - "pkg"
   - "mboct-octave-pkg (>=0.1.0)"
-  ubuntu2204:
+  ubuntu2604:
   - "libmkl-full-dev"
   - "libmetis-dev"
   - "libgtest-dev"

--- a/packages/mboct-octave-pkg.yaml
+++ b/packages/mboct-octave-pkg.yaml
@@ -34,6 +34,6 @@ versions:
   depends:
   - "octave (>= 5.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libgtest-dev"
 ---

--- a/packages/miscellaneous.yaml
+++ b/packages/miscellaneous.yaml
@@ -31,7 +31,7 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "units"
 - id: "1.3.1"
   date: "2024-07-24"
@@ -40,7 +40,7 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "units"
 - id: "1.3.0"
   date: "2019-10-27"
@@ -49,6 +49,6 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "units"
 ---

--- a/packages/mqtt.yaml
+++ b/packages/mqtt.yaml
@@ -34,7 +34,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libpaho-mqtt-dev"
 - id: "0.0.5"
   date: "2024-04-11"
@@ -43,7 +43,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libpaho-mqtt-dev"
 - id: "0.0.4"
   date: "2023-07-25"
@@ -52,7 +52,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libpaho-mqtt-dev"
 - id: "0.0.3"
   date: "2022-08-18"
@@ -61,7 +61,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libpaho-mqtt-dev"
 - id: "0.0.2"
   date: "2022-07-21"
@@ -70,7 +70,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libpaho-mqtt-dev"
 - id: "0.0.1"
   date: "2022-06-30"
@@ -79,6 +79,6 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libpaho-mqtt-dev"
 ---

--- a/packages/msh.yaml
+++ b/packages/msh.yaml
@@ -36,7 +36,7 @@ versions:
   - "octave (>= 3.0.0)"
   - "splines"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "gmsh"
 - id: "1.0.11"
   date: "2022-07-22"
@@ -46,7 +46,7 @@ versions:
   - "octave (>= 3.0.0)"
   - "splines"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "gmsh"
 - id: "1.0.10"
   date: "2014-02-21"
@@ -56,6 +56,6 @@ versions:
   - "octave (>= 3.0.0)"
   - "splines"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "gmsh"
 ---

--- a/packages/netcdf.yaml
+++ b/packages/netcdf.yaml
@@ -33,7 +33,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libnetcdf-dev"
 - id: "1.0.18"
   date: "2024-09-24"
@@ -42,7 +42,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libnetcdf-dev"
 - id: "1.0.17"
   date: "2023-09-18"
@@ -51,7 +51,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libnetcdf-dev"
 - id: "1.0.16"
   date: "2022-09-16"
@@ -60,7 +60,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libnetcdf-dev"
 - id: "1.0.15"
   date: "2022-09-12"
@@ -69,7 +69,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libnetcdf-dev"
 - id: "1.0.14"
   date: "2020-10-14"
@@ -78,7 +78,7 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libnetcdf-dev"
 - id: "1.0.13"
   date: "2020-03-13"
@@ -87,6 +87,6 @@ versions:
   depends:
   - "octave (>= 3.8.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libnetcdf-dev"
 ---

--- a/packages/octproj.yaml
+++ b/packages/octproj.yaml
@@ -32,6 +32,6 @@ versions:
   depends:
   - "octave (>= 3.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libproj-dev"
 ---

--- a/packages/odbc.yaml
+++ b/packages/odbc.yaml
@@ -31,7 +31,7 @@ versions:
   depends:
   - "octave (>= 6.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "unixodbc-dev"
   - "libsqliteodbc"
 - id: "0.0.5"
@@ -41,7 +41,7 @@ versions:
   depends:
   - "octave (>= 6.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "unixodbc-dev"
   - "libsqliteodbc"
 - id: "0.0.4"
@@ -51,7 +51,7 @@ versions:
   depends:
   - "octave (>= 6.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "unixodbc-dev"
   - "libsqliteodbc"
 - id: "0.0.3"
@@ -61,7 +61,7 @@ versions:
   depends:
   - "octave (>= 6.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "unixodbc-dev"
   - "libsqliteodbc"
 - id: "0.0.2"
@@ -71,7 +71,7 @@ versions:
   depends:
   - "octave (>= 6.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "unixodbc-dev"
   - "libsqliteodbc"
 ---

--- a/packages/pythonic.yaml
+++ b/packages/pythonic.yaml
@@ -37,7 +37,7 @@ versions:
   depends:
   - "octave (>= 6.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "python3-dev"
 - id: "0.1.2"
   date: "2023-07-23"
@@ -46,7 +46,7 @@ versions:
   depends:
   - "octave (>= 6.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "python3-dev"
 - id: "0.0.1"
   date: "2019-05-22"

--- a/packages/rtree.yaml
+++ b/packages/rtree.yaml
@@ -29,6 +29,6 @@ versions:
   depends:
   - "octave (>= 6.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libjansson-dev"
 ---

--- a/packages/sqlite.yaml
+++ b/packages/sqlite.yaml
@@ -31,7 +31,7 @@ versions:
   depends:
   - "octave (>= 6.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libsqlite3-dev"
 - id: "0.1.2"
   date: "2025-12-17"
@@ -40,7 +40,7 @@ versions:
   depends:
   - "octave (>= 6.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libsqlite3-dev"
 - id: "0.1.1"
   date: "2025-10-11"
@@ -49,7 +49,7 @@ versions:
   depends:
   - "octave (>= 6.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libsqlite3-dev"
 - id: "0.1.0"
   date: "2024-01-11"
@@ -58,7 +58,7 @@ versions:
   depends:
   - "octave (>= 6.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libsqlite3-dev"
 - id: "0.0.3"
   date: "2023-03-27"
@@ -67,7 +67,7 @@ versions:
   depends:
   - "octave (>= 6.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libsqlite3-dev"
 - id: "0.0.2"
   date: "2022-10-21"
@@ -76,7 +76,7 @@ versions:
   depends:
   - "octave (>= 6.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libsqlite3-dev"
 - id: "0.0.1"
   date: "2022-10-12"
@@ -85,6 +85,6 @@ versions:
   depends:
   - "octave (>= 6.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libsqlite3-dev"
 ---

--- a/packages/symbolic.yaml
+++ b/packages/symbolic.yaml
@@ -41,7 +41,7 @@ versions:
   depends:
   - "octave (>= 6.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "python3-sympy"
 - id: "3.2.1"
   date: "2024-05-15"
@@ -50,7 +50,7 @@ versions:
   depends:
   - "octave (>= 5.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "python3-sympy"
 - id: "3.1.1"
   date: "2023-03-19"
@@ -59,7 +59,7 @@ versions:
   depends:
   - "octave (>= 5.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "python3-sympy"
 - id: "3.0.1"
   date: "2022-08-09"
@@ -68,7 +68,7 @@ versions:
   depends:
   - "octave (>= 5.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "python3-sympy"
 - id: "3.0.0"
   date: "2022-07-05"
@@ -77,7 +77,7 @@ versions:
   depends:
   - "octave (>= 5.1.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "python3-sympy"
 - id: "2.9.0"
   date: "2020-03-04"

--- a/packages/tablicious.yaml
+++ b/packages/tablicious.yaml
@@ -32,7 +32,7 @@ versions:
   depends:
   - "octave (>= 7.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "tzdata"
 - id: "0.4.6"
   date: "2026-02-16"
@@ -41,7 +41,7 @@ versions:
   depends:
   - "octave (>= 7.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "tzdata"
 - id: "0.4.5"
   date: "2025-07-03"
@@ -50,7 +50,7 @@ versions:
   depends:
   - "octave (>= 7.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "tzdata"
 - id: "0.4.4"
   date: "2024-10-23"
@@ -59,7 +59,7 @@ versions:
   depends:
   - "octave (>= 7.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "tzdata"
 - id: "0.4.3"
   date: "2024-04-06"
@@ -68,7 +68,7 @@ versions:
   depends:
   - "octave (>= 7.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "tzdata"
 - id: "0.4.2"
   date: "2024-02-07"
@@ -77,7 +77,7 @@ versions:
   depends:
   - "octave (>= 7.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "tzdata"
 - id: "0.4.1"
   date: "2024-02-07"
@@ -86,7 +86,7 @@ versions:
   depends:
   - "octave (>= 7.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "tzdata"
 - id: "0.4.0"
   date: "2024-02-07"
@@ -95,7 +95,7 @@ versions:
   depends:
   - "octave (>= 7.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "tzdata"
 - id: "0.3.7"
   date: "2023-01-06"
@@ -104,7 +104,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "tzdata"
 - id: "0.3.6"
   date: "2021-07-05"
@@ -113,7 +113,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "tzdata"
 - id: "0.3.5"
   date: "2020-01-31"

--- a/packages/video.yaml
+++ b/packages/video.yaml
@@ -31,7 +31,7 @@ versions:
   depends:
   - "octave (>= 4.4.1)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libavcodec-dev"
   - "libavformat-dev"
   - "libswscale-dev"
@@ -42,7 +42,7 @@ versions:
   depends:
   - "octave (>= 4.4.1)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libavcodec-dev"
   - "libavformat-dev"
   - "libswscale-dev"
@@ -53,7 +53,7 @@ versions:
   depends:
   - "octave (>= 4.4.1)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libavcodec-dev"
   - "libavformat-dev"
   - "libswscale-dev"
@@ -64,7 +64,7 @@ versions:
   depends:
   - "octave (>= 4.4.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libavcodec-dev"
   - "libavformat-dev"
   - "libswscale-dev"
@@ -75,7 +75,7 @@ versions:
   depends:
   - "octave (>= 4.4.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libavcodec-dev"
   - "libavformat-dev"
   - "libswscale-dev"
@@ -86,7 +86,7 @@ versions:
   depends:
   - "octave (>= 4.4.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libavcodec-dev"
   - "libavformat-dev"
   - "libswscale-dev"

--- a/packages/zeromq.yaml
+++ b/packages/zeromq.yaml
@@ -34,7 +34,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libzmq3-dev"
 - id: "1.5.6"
   date: "2023-08-11"
@@ -43,7 +43,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libzmq3-dev"
 - id: "1.5.5"
   date: "2022-10-17"
@@ -52,7 +52,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libzmq3-dev"
 - id: "1.5.4"
   date: "2022-05-02"
@@ -61,7 +61,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libzmq3-dev"
 - id: "1.5.3"
   date: "2021-07-15"
@@ -70,7 +70,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libzmq3-dev"
 - id: "1.5.2"
   date: "2020-10-13"
@@ -79,7 +79,7 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libzmq3-dev"
 - id: "1.5.1"
   date: "2020-04-28"
@@ -88,6 +88,6 @@ versions:
   depends:
   - "octave (>= 4.0.0)"
   - "pkg"
-  ubuntu2204:
+  ubuntu2604:
   - "libzmq3-dev"
 ---


### PR DESCRIPTION
Octave latest container image `ghcr.io/gnu-octave/octave:latest` updated: https://github.com/gnu-octave/docker/commit/50aec3dd2d64262fc16c1769622813189b0cc749