### PR TITLE
NaN-package: v.3.7.2

### DIFF
--- a/packages/nan.yaml
+++ b/packages/nan.yaml
@@ -28,6 +28,13 @@ maintainers:
 - name: "Alois Schlögl"
   contact: "alois.schloegl@gmail.com"
 versions:
+- id: "3.7.1"
+  date: "2022-08-16"
+  sha256: "a6924ba7dfc6bb2c823cdbb9fc9452d9d21fc0b32b71eefe60a57cc07c46592d"
+  url: "https://pub.ista.ac.at/~schloegl/matlab/NaN/nan-3.7.1.tar.gz"
+  depends:
+  - "octave (>= 4.4.1)"
+  - "pkg"
 - id: "3.7.0"
   date: "2022-05-09"
   sha256: "77d27a05f34578ce4bb4caad8746e848f77d822614e362819f1aec50298a2b5b"

--- a/packages/nan.yaml
+++ b/packages/nan.yaml
@@ -28,10 +28,10 @@ maintainers:
 - name: "Alois Schlögl"
   contact: "alois.schloegl@gmail.com"
 versions:
-- id: "3.7.1"
-  date: "2022-08-16"
-  sha256: "a6924ba7dfc6bb2c823cdbb9fc9452d9d21fc0b32b71eefe60a57cc07c46592d"
-  url: "https://pub.ista.ac.at/~schloegl/matlab/NaN/nan-3.7.1.tar.gz"
+- id: "3.7.2"
+  date: "2026-04-28"
+  sha256: "d2d2bac3f1d790428df2f7a396c6a1ffed93e91e29ab13678f641deaf021a216"
+  url: "https://pub.ista.ac.at/~schloegl/matlab/NaN/nan-3.7.2.tar.gz"
   depends:
   - "octave (>= 4.4.1)"
   - "pkg"


### PR DESCRIPTION
 2022-08-16: Release of NaN-toolbox 3.7.1

* kurtosis, skewness:
    add support for FLAG input argument, supporting
    biased and unbiased estimation.
    Compatibility tests with Octave and Matlab are added.
    It will break backwards compatibility, the previous
    version is supported by FLAG=-1.

* fishers_exact_test:
    extend to non-square contingency tables according to
    https://mathworld.wolfram.com/FishersExactTest.html

