### PR TITLE
Add version 1.2.7 to datatypes.yaml

### DIFF
--- a/packages/datatypes.yaml
+++ b/packages/datatypes.yaml
@@ -24,6 +24,13 @@ maintainers:
 - name: "Andreas Bertsatos"
   contact: "abertsatos@biol.uoa.gr"
 versions:
+- id: "1.2.7"
+  date: "2026-07-21"
+  sha256: "159340dc37590b4bd993978c037730bdf09161dd11dd28a3b6b76ba4ed7ad644"
+  url: "https://github.com/pr0m1th3as/datatypes/releases/download/release-1.2.7/datatypes-1.2.7.tar.gz"
+  depends:
+  - "octave (>= 11.1.0)"
+  - "pkg"
 - id: "1.2.6"
   date: "2026-07-08"
   sha256: "08b02c9dd072c62f9c6a4061e715403b212cc327104702be78b9824c137a1f09"


### PR DESCRIPTION
Added version 1.2.7 with dependencies for octave and pkg.