### PR TITLE
Add version 1.3.1 to datatypes.yaml

### DIFF
--- a/packages/datatypes.yaml
+++ b/packages/datatypes.yaml
@@ -24,6 +24,13 @@ maintainers:
 - name: "Andreas Bertsatos"
   contact: "abertsatos@biol.uoa.gr"
 versions:
+- id: "1.3.1"
+  date: "2026-08-07"
+  sha256: "c43fb535b56877bce775db0bf086d144a42aaa4c86c46e1f2604241a1d9f238b"
+  url: "https://github.com/pr0m1th3as/datatypes/releases/download/release-1.3.1/datatypes-1.3.1.tar.gz"
+  depends:
+  - "octave (>= 11.1.0)"
+  - "pkg"
 - id: "1.3.0"
   date: "2026-08-03"
   sha256: "3670eedd6af6c5cefe699d6796749d7eefb73fe08cda8504f53f126fc828d6fd"


### PR DESCRIPTION
Added version 1.3.1 with dependencies for octave and pkg.