### PR TITLE
Add version 1.3.2 to datatypes.yaml

### DIFF
--- a/packages/datatypes.yaml
+++ b/packages/datatypes.yaml
@@ -24,6 +24,13 @@ maintainers:
 - name: "Andreas Bertsatos"
   contact: "abertsatos@biol.uoa.gr"
 versions:
+- id: "1.3.2"
+  date: "2026-08-07"
+  sha256: "9f89348b5ad75a2df4cac2d4ab47be35479f03ad256c9cc62aadbb534106057f"
+  url: "https://github.com/pr0m1th3as/datatypes/releases/download/release-1.3.2/datatypes-1.3.2.tar.gz"
+  depends:
+  - "octave (>= 11.1.0)"
+  - "pkg"
 - id: "1.3.1"
   date: "2026-08-07"
   sha256: "c43fb535b56877bce775db0bf086d144a42aaa4c86c46e1f2604241a1d9f238b"


### PR DESCRIPTION
Added version 1.3.2 with dependencies for octave and pkg.