### PR TITLE
packages/femoctave.yaml: release 2.1.10

### DIFF
--- a/packages/femoctave.yaml
+++ b/packages/femoctave.yaml
@@ -24,6 +24,13 @@ maintainers:
 - name: "Andreas Stahel"
   contact:
 versions:
+- id: "2.1.10"
+  date: "2026-08-25"
+  sha256: "2f22d25206a296870b02d0b32ae8f9173eaf3e612860a74ce7da2b11029e208b"
+  url: "https://github.com/AndreasStahel/FEMoctave/archive/v.2.1.10.tar.gz"
+  depends:
+  - "octave (>= 5.2.0)"
+  - "pkg"
 - id: "2.1.9"
   date: "2026-05-09"
   sha256: "d2c6ced2299c4d98df367b0aada0089b3fa925d63c8ed459e28c18d426a4af58"


### PR DESCRIPTION
Added version 2.1.10 with dependencies for octave and pkg.

Release requested by author via email https://github.com/AndreasStahel/FEMoctave/releases/tag/v.2.1.10