### PR TITLE
Add version 2.20.1 to image package

### DIFF
--- a/packages/image.yaml
+++ b/packages/image.yaml
@@ -30,6 +30,13 @@ maintainers:
 - name: "Avinoam Kalma"
   contact:
 versions:
+- id: "2.20.1"
+  date: "2026-09-03"
+  sha256: "b4b6865e7f65ee5b9c254a69128bf10e93b38bc27f5bc5b973fef300217fc725"
+  url: "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/image-2.20.1.tar.gz"
+  depends:
+  - "octave (>= 8.1.0)"
+  - "pkg"
 - id: "2.20.0"
   date: "2026-03-11"
   sha256: "5f8d97ed7f7d18ce854a8174bbf819e9e3a703bcd1cb2ca8b1ad15b9ef329522"


### PR DESCRIPTION
** image 2.20.1 is a bug fix release.

 ** Improve image spatial filters for higher-dimensional inputs (bug #45088).

 ** edge: Allow binary input image for edge (bug #55432)

 ** mormxcorr2: re-write the code and optimize it to make it compatible
    with MATLAB (bug #50151)
